### PR TITLE
SDK-1043: Update module to display modal QR

### DIFF
--- a/tests/acceptance/YotiModuleCest.php
+++ b/tests/acceptance/YotiModuleCest.php
@@ -12,8 +12,25 @@ class YotiModuleCest
     {
         $I->amLoggedInAsAdmin();
         $I->placeTheYotiModule();
+
         $I->amOnPage('/');
-        $I->waitForElement('a[data-scenario-id="test_scenario_id"][data-application-id="test_app_id"]');
-        $I->see('Use Yoti');
+
+        $config = array(
+            'domId' => 'yoti-button-1',
+            'clientSdkId' => 'test_sdk_id',
+            'scenarioId' => 'test_scenario_id',
+            'button' => array(
+                'label' => 'Use Yoti',
+            ),
+        );
+        $I->canSeeInSource(json_encode($config));
+        $I->waitForElement('#yoti-button-1 iframe');
+
+        $I->doFrontEndLogin();
+        $I->amOnPage('/');
+
+        $config['button']['label'] = 'Link to Yoti';
+        $I->canSeeInSource(json_encode($config));
+        $I->waitForElement('#yoti-button-1 iframe');
     }
 }

--- a/yoti/modules/mod_yoti/tmpl/default.php
+++ b/yoti/modules/mod_yoti/tmpl/default.php
@@ -4,7 +4,6 @@
  */
 defined('_JEXEC') or die('Restricted access'); // no direct access
 
-use Yoti\YotiClient;
 
 // Don't show button until we have pem, Client SDK ID And Scenario ID.
 $config = ModYotiHelper::getConfig();
@@ -16,43 +15,29 @@ if (!$config['yoti_sdk_id']
 }
 
 $currentUser = JFactory::getUser();
+$buttonId = ModYotiHelper::createButtonId();
 
-$document = JFactory::getDocument();
+
 // Add Yoti button library
-$document->addScript(ModYotiHelper::YOTI_BUTTON_JS_LIBRARY);
+$document = JFactory::getDocument();
+$document->addScript(JUri::base() . 'components/com_yoti/assets/loader.js', array(), array('defer' => true));
 $document->addStyleSheet(JUri::base() . 'components/com_yoti/assets/styles.css');
-
-$script = [];
-
-// If connect url starts with 'https://staging' then we are in staging mode.
-$isStaging = strpos(YotiClient::CONNECT_BASE_URL, 'https://staging') === 0;
-if ($isStaging) {
-    // Base url for connect.
-    $baseUrl = preg_replace('/^(.+)\/connect$/', '$1', YotiClient::CONNECT_BASE_URL);
-    $script[] = sprintf('_ybg.config.qr = "%s/qr/";', $baseUrl);
-    $script[] = sprintf('_ybg.config.service = "%s/connect/";', $baseUrl);
-}
-
-// Add init()
-$script[] = '_ybg.init();';
-$linkButton = '<span
-            data-yoti-application-id="' . htmlspecialchars($config['yoti_app_id']) . '"
-            data-yoti-type="inline"
-            data-yoti-scenario-id="' . htmlspecialchars($config['yoti_scenario_id']) . '"
-            data-size="small">
-            %s
-        </span>
-        <script>' . implode("\r\n", $script) . '</script>';
-
-if ($currentUser->guest) {
-    $url = ModYotiHelper::getLoginUrl();
-    $button = sprintf($linkButton, ModYotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT);
-} else {
-    if (!YotiModelUser::yotiUserIsLinkedToJoomlaUser($currentUser->id)) {
-        $url = ModYotiHelper::getLoginUrl();
-        $button = sprintf($linkButton, 'Link to Yoti');
-    } else {
-        $button = '<strong>Yoti</strong>  Linked';
-    }
-}
-echo '<div class="yoti-connect">' . $button . '</div>';
+?>
+<div class="yoti-connect">
+    <?php if ($currentUser->guest || !YotiModelUser::yotiUserIsLinkedToJoomlaUser($currentUser->id)) : ?>
+        <div id="<?php echo htmlspecialchars($buttonId); ?>" class="yoti-button"></div>
+        <script>
+        var yotiConfig = yotiConfig || { elements: [] };
+        yotiConfig.elements.push(<?php echo json_encode(array(
+            'domId' => htmlspecialchars($buttonId),
+            'clientSdkId' =>  htmlspecialchars($config['yoti_sdk_id']),
+            'scenarioId' =>  htmlspecialchars($config['yoti_scenario_id']),
+            'button' => array(
+                'label' => $currentUser->guest ? ModYotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT : 'Link to Yoti',
+            ),
+        )); ?>);
+        </script>
+    <?php else : ?>
+        <strong>Yoti</strong> Linked
+    <?php endif; ?>
+</div>

--- a/yoti/site/YotiHelper.php
+++ b/yoti/site/YotiHelper.php
@@ -36,8 +36,10 @@ class YotiHelper
 
     /**
      * Yoti Button javascript library.
+     *
+     * @deprecated this is now configured in loader.js
      */
-    const YOTI_BUTTON_JS_LIBRARY = 'https://sdk.yoti.com/clients/browser.2.1.0.js';
+    const YOTI_BUTTON_JS_LIBRARY = 'https://www.yoti.com/share/client/';
 
     /**
      * Yoti Hub URL.
@@ -774,5 +776,17 @@ class YotiHelper
         }
 
         return new ProfileAdapter($userProfile);
+    }
+
+    /**
+     * Creates a unique button ID for the current request.
+     *
+     * @return string
+     *   The button ID.
+     */
+    public static function createButtonId()
+    {
+        static $x = 0;
+        return 'yoti-button-' . ++$x;
     }
 }

--- a/yoti/site/assets/loader.js
+++ b/yoti/site/assets/loader.js
@@ -1,0 +1,14 @@
+(function(){
+    // Create browser script tag.
+    var script = document.createElement('script');
+    script.type='text/javascript';
+    script.async='async';
+    script.src='https://www.yoti.com/share/client/';
+
+    // Initialise button once browser JS is loaded.
+    script.addEventListener('load', function() {
+        window.Yoti.Share.init(yotiConfig);
+    });
+
+    document.head.appendChild(script);
+})();

--- a/yoti/site/assets/styles.css
+++ b/yoti/site/assets/styles.css
@@ -24,11 +24,13 @@
     float:left;
     width:12em;
     padding:3px 0;
-
-
 }
 
 #users-profile-custom-yotiprofile dd
 {
     padding:3px 0;
+}
+
+.yoti-connect .yoti-button {
+    height: 50px;
 }


### PR DESCRIPTION
### Changed
- Updated module to display modal QR

`yoti/site/assets/loader.js` takes care of adding the share client script to the `<head>` and triggers `window.Yoti.Share.init()` once loaded - this happens once per page load.

The only way I could find in Joomla to run `window.Yoti.Share.init()` after all the config is added to `var yotiConfig`, was to use the `defer` attribute on the `loader.js` script tag, which seems to be working reliably.

