### PR TITLE
SDK-986: Install mariadb-client

### DIFF
--- a/docker/app.base.dockerfile
+++ b/docker/app.base.dockerfile
@@ -10,7 +10,7 @@ COPY ./keys/server.key /etc/apache2/ssl/server.key
 RUN a2enmod ssl
 
 # Install additional packages.
-RUN apt-get update && apt-get install -y zip unzip git vim nano
+RUN apt-get update && apt-get install -y zip unzip git vim nano mariadb-client
 
 # Install Composer.
 RUN EXPECTED_SIGNATURE="$(curl https://composer.github.io/installer.sig)" \


### PR DESCRIPTION
### Fixed
- Installing `mariadb-client` (replaces `mysql-client`, which was removed in #19)

> Note: `mariadb-client` replaces `mysql-client` as `php` images now use Debian 10 (Buster) as its base image and Buster ships with _MariaDB_