### PR TITLE
NA: Update Chrome options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 # Yoti Joomla Extension
 
+[![Build Status](https://travis-ci.com/getyoti/yoti-joomla.svg?branch=master)](https://travis-ci.com/getyoti/yoti-joomla)
+
 This repository contains the tools you need to quickly integrate your Joomla back-end with Yoti so that your users can share their identity details with your application in a secure and trusted way. The extension uses the Yoti PHP SDK. If you're interested in finding out more about the SDK, click [here](https://github.com/getyoti/yoti-php-sdk).
 
 ## Installing the extension

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -15,6 +15,9 @@ modules:
             window_size: 1440x1440
             capabilities:
               unexpectedAlertBehaviour: 'accept'
+              'goog:chromeOptions':
+                args: ['ignore-certificate-errors']
+                w3c: false
             username: 'admin'
             password: 'admin'
             database host: 'joomladb'


### PR DESCRIPTION
### Fixed
- Updated chrome options to fix Travis builds:
  - `args: ['ignore-certificate-errors']` to ignore self signed cert warning
  - `w3c: false` - temporarily fixes W3C incompatibility issues [see discussion here](https://stackoverflow.com/questions/56452798/how-to-turn-off-w3c-in-chromedriver-to-address-the-error-unknown-command-cannot)

### Added
- Travis badge to README